### PR TITLE
docs: fix link to tool repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # asdf-typos [![Build](https://github.com/aschiavon91/asdf-typos/actions/workflows/build.yml/badge.svg)](https://github.com/aschiavon91/asdf-typos/actions/workflows/build.yml) [![Lint](https://github.com/aschiavon91/asdf-typos/actions/workflows/lint.yml/badge.svg)](https://github.com/aschiavon91/asdf-typos/actions/workflows/lint.yml)
 
 
-[typos](https://github.com/aschiavon91/asdf-typos) plugin for the [asdf version manager](https://asdf-vm.com).
+[typos](https://github.com/crate-ci/typos) plugin for the [asdf version manager](https://asdf-vm.com).
 
 </div>
 


### PR DESCRIPTION
Thanks for creating this plugin!

As I understand it and the current template, this link is expected to point to the tool repository rather than the plugin repository.

https://github.com/asdf-vm/asdf-plugin-template/blob/d038a915da6a397cfc7dd2b2638e89b8e74a3407/template/README-github.md#L5

And I agree that this is better for asdf users, they can easily understand what the plugin aims at. 🙏 


