### PR TITLE
chore: add dependabot config to keep latest actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
I found some actions are older as https://github.com/aschiavon91/asdf-typos/blob/13cb369827ea4e31401f76b95fc84f4d0a702609/.github/workflows/build.yml#L20 when addressing https://github.com/aschiavon91/asdf-typos/pull/5

This PR is based on https://github.com/asdf-vm/asdf-plugin-template/commit/d6e36ebb7de2ad212841fc3f478a51ded09a6447 and https://github.com/asdf-vm/asdf-plugin-template/pull/76