### PR TITLE
feat: support aarch64 on darwin

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,11 +13,16 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          - macos-latest
+          - macos-14 # M1
+          - macos-13 # Intel
         tool-version:
           - 'latest'
           # Supporting oldest
           - '1.1.0'
+        exclude:
+          # typos supported aarch64 darwin since 1.17.1
+          - os: macos-14
+            tool-version: '1.1.0'
     runs-on: ${{ matrix.os }}
     steps:
       - name: asdf_plugin_test

--- a/bin/download
+++ b/bin/download
@@ -18,6 +18,7 @@ esac
 
 case "$(uname -m)" in
 x86_64*) ARCHITECTURE="x86_64" ;;
+aarch64 | arm64) ARCHITECTURE="aarch64" ;;
 *) fail "Unsupported architecture" ;;
 esac
 


### PR DESCRIPTION
This PR removes the restriction and add the CI for M1 mac

Following URLs are related.

https://github.com/crate-ci/typos/pull/908
https://github.com/crate-ci/typos/blob/0afab6199de25a080e00812211834b939c012c25/CHANGELOG.md?plain=1#L39-L43
https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/